### PR TITLE
Makes Cron work on my single domain system

### DIFF
--- a/modules/api/cron.php
+++ b/modules/api/cron.php
@@ -12,7 +12,7 @@ ini_set('max_execution_time', 600); //600 seconds = 10 minutes
 
 $cron = new cron();
 // remove hardcoding for multi-domain usage
-// $cron->domain_id=1;
+$cron->domain_id=domain_id::get();
 $message = $cron->run();
 
 try 


### PR DESCRIPTION
My system is IIS7.5 + PHP 5.4.26

Cron API is called from a Scheduled Task, opening internet explorer with the URL to the Cron API as an argument

http://www.domain.com/simpleinvoices/index.php?module=api&view=cron
